### PR TITLE
Fixed issue #174.

### DIFF
--- a/app/src/main/java/com/arom/jobzi/LoginActivity.java
+++ b/app/src/main/java/com/arom/jobzi/LoginActivity.java
@@ -65,7 +65,31 @@ public class LoginActivity extends AppCompatActivity {
 
         final String email = emailTextView.getText().toString();
         final String password = passwordTextView.getText().toString();
-
+        
+        // This code is sadly repeated in the UserProfileUtil class but this use case is incompatible
+        // with the methods in that class.
+        if(email.isEmpty()) {
+            
+            Toast.makeText(this, "Please provide an email address.", Toast.LENGTH_SHORT).show();
+    
+            loginButton.setEnabled(true);
+            signupButton.setEnabled(true);
+            
+            return;
+            
+        }
+        
+        if(password.isEmpty()) {
+    
+            Toast.makeText(this, "Please provide a password.", Toast.LENGTH_SHORT).show();
+    
+            loginButton.setEnabled(true);
+            signupButton.setEnabled(true);
+    
+            return;
+    
+        }
+        
         auth.signInWithEmailAndPassword(email, password).addOnCompleteListener(new OnCompleteListener<AuthResult>() {
             @Override
             public void onComplete(@NonNull Task<AuthResult> task) {

--- a/app/src/main/java/com/arom/jobzi/util/UserProfileUtil.java
+++ b/app/src/main/java/com/arom/jobzi/util/UserProfileUtil.java
@@ -147,6 +147,16 @@ public final class UserProfileUtil {
         
     }
     
+    /**
+     * Validates the <code>user</code> and <code>password</code> provided using {@link #validateUserInfo(User, String)}
+     * <i>and</i> uses the provided <code>context</code> to display an appropriate <code>Toast</code> detailing the
+     * exact error.
+     *
+     * @param context
+     * @param user
+     * @param password
+     * @return <code>true</code> if the information in <code>user</code> is valid and <code>false</code> otherise.
+     */
     public boolean validateUserInfoWithError(Context context, User user, String password) {
         
         ValidationResult validationResult = validateUserInfo(user, password);


### PR DESCRIPTION
- Added documentation to UserProfileUtil method. This was not used due to other issues.
- The solution is not elegant and has redundent code. However, in order to implement it correctly (i.e. using the UserProfileUtil class), we would need to use something similar to the proxy design pattern to pass in objects with only the email and password as opposed to everything else a User object might hold (although using UserProfileUtil works to determine if either the email o password are empty, when both are filled in, the method will t ry to check the enxt field which is not being used in the LoginActivity and would cause a crash because that method does not expect null values).